### PR TITLE
Scenario: Verify that user is able to see “Incorrect conversation length”
  with red color if he enters invalid credentials,
  immediately after conversation name input box

### DIFF
--- a/src/test/java/com/cydeo/pages/TalkPageByAnda.java
+++ b/src/test/java/com/cydeo/pages/TalkPageByAnda.java
@@ -22,6 +22,8 @@ public class TalkPageByAnda {
     public WebElement ConversationNameBox;
 
 
+@FindBy (xpath = "//div[@class='new-group-conversation talk-modal']")
+    public WebElement ConversationNameModal;
 
 
 

--- a/src/test/java/com/cydeo/step_definitions/Talk_StepDefinitions_Anda.java
+++ b/src/test/java/com/cydeo/step_definitions/Talk_StepDefinitions_Anda.java
@@ -58,13 +58,19 @@ talkPageByAnda.ConversationNameBox.click();
     public void verify_is_same_as_the_input(String conversationName) {
         String expectedConversationName= "QA Engineers 1#";
         String actualConversationName=talkPageByAnda.ConversationNameBox.getText();
-
-        Assert.assertEquals(expectedConversationName,actualConversationName);
+//there is a problem here, it can't verify, the test fails
+        Assert.assertEquals(actualConversationName, expectedConversationName);
     }
 
 
+    @And("write an invalid conversation name")
+    public void writeAnInvalidConversationName() {
+        talkPageByAnda.ConversationNameBox.sendKeys("QA the best group in company");
+    }
 
+    @Then("verify that the message-Incorrect conversation length- is appeared in the table")
+    public void verifyThatTheMessageIncorrectConversationLengthIsAppearedInTheTable() {
 
-
-
+        Assert.assertTrue(talkPageByAnda.ConversationNameModal.getText().contains("Incorrect conversation length"));
+    }
 }

--- a/src/test/resources/features/TalkByAnda.feature
+++ b/src/test/resources/features/TalkByAnda.feature
@@ -11,7 +11,7 @@ Feature: Talk Functionality
     And click the talk module
    Then Click plus sign in order to create a new conversation
 
-@Anda
+
     Scenario:  Verify that user is able to type type valid conversation name
     which is no longer than 20 characters,and it can be as many words as he wants.
     User can put in conversation name box special characters and numbers.
@@ -24,3 +24,14 @@ Feature: Talk Functionality
    And Write a "conversation name"
   Then verify "conversation name" is same as the input
 
+  @Anda
+  Scenario:  Verify that user is able to see “Incorrect conversation length”
+  with red color if he enters invalid credentials,
+  immediately after conversation name input box
+    Given login to the hectorware
+    And navigate to talk module
+    And click the talk module
+    And  Click plus sign in order to create a new conversation
+    And Click the conversation name box
+    And write an invalid conversation name
+    Then verify that the message-Incorrect conversation length- is appeared in the table


### PR DESCRIPTION
The user is not able to see the message "Incorrect conversation length", after entering invalid credentials
There is a bug